### PR TITLE
Support for camel case

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 out
 node_modules
+.vscode-test
 *.vsix

--- a/package.json
+++ b/package.json
@@ -19,6 +19,22 @@
         "onLanguage:typescriptreact",
         "onLanguage:javascriptreact"
     ],
+    "contributes": {
+        "configuration": {
+            "type": "object",
+            "title": "CSS Modules Configuration",
+            "properties": {
+                "cssModules.camelCase": {
+                    "type": [
+                        "boolean",
+                        "string"
+                    ],
+                    "default": false,
+                    "description": "Transform classnames in autocomplete suggestions."
+                }
+            }
+        }
+    },
     "main": "./out/src/extension",
     "scripts": {
         "vscode:prepublish": "tsc -p ./",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,15 +1,26 @@
 "use strict";
-import { languages, ExtensionContext, DocumentFilter } from "vscode";
+import {
+    languages,
+    ExtensionContext,
+    DocumentFilter,
+    workspace,
+} from "vscode";
 import { CSSModuleCompletionProvider } from "./CompletionProvider";
 import { CSSModuleDefinitionProvider } from "./DefinitionProvider";
+import { CamelCaseValues } from "./utils";
+
+const extName = "cssModules";
 
 export function activate(context: ExtensionContext) {
     const mode: DocumentFilter = [
         { language: "typescriptreact", scheme: "file" },
         { language: "javascriptreact", scheme: "file" }
     ];
+    const configuration = workspace.getConfiguration(extName);
+    const camelCaseConfig: CamelCaseValues = configuration.get("camelCase", false);
+
     context.subscriptions.push(
-        languages.registerCompletionItemProvider(mode, new CSSModuleCompletionProvider(), ".")
+        languages.registerCompletionItemProvider(mode, new CSSModuleCompletionProvider(camelCaseConfig), ".")
     );
     context.subscriptions.push(
         languages.registerDefinitionProvider(mode, new CSSModuleDefinitionProvider())

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -40,3 +40,5 @@ export function getAllClassNames(filePath: string, keyword: string): string[] {
     const uniqNames = _.uniq(classNames).map(item => item.slice(1));
     return keyword !== "" ? uniqNames.filter(item => item.indexOf(keyword) !== -1) : uniqNames;
 }
+
+export type CamelCaseValues = false | true | "dashes";

--- a/test/CompletionProvider.test.ts
+++ b/test/CompletionProvider.test.ts
@@ -3,6 +3,8 @@ import * as vscode from "vscode";
 import * as path from "path";
 import { CSSModuleCompletionProvider } from "../src/CompletionProvider";
 
+import { CamelCaseValues } from "../src/utils";
+
 const rootPath = path.join(__dirname, "../..");
 const tsxFile = path.join(rootPath, "./test/fixtures/sample.jsx");
 const uri = vscode.Uri.file(tsxFile);
@@ -11,7 +13,16 @@ function testCompletion(position: vscode.Position) {
     return vscode.workspace.openTextDocument(uri).then(text => {
         const provider = new CSSModuleCompletionProvider();
         return provider.provideCompletionItems(text, position).then(items => {
-            assert.equal(4, items.length);
+            assert.equal(5, items.length);
+        });
+    });
+}
+
+function testCompletionWithCase(position: vscode.Position, camelCaseConfig: CamelCaseValues, assertions: Array<Function>) {
+    return vscode.workspace.openTextDocument(uri).then(text => {
+        const provider = new CSSModuleCompletionProvider(camelCaseConfig);
+        return provider.provideCompletionItems(text, position).then(items => {
+            assertions.map((assertion) => assertion(items));
         });
     });
 }
@@ -29,6 +40,42 @@ test("test commonJS style completion", () => {
     const position = new vscode.Position(4, 20);
     return Promise.resolve(
         testCompletion(position)
+    ).catch(err => {
+        assert.ok(false, `error in OpenTextDocument ${err}`);
+    });
+});
+
+test("test camelCase:false style completion", () => {
+    const position = new vscode.Position(5, 21);
+    return Promise.resolve(
+        testCompletionWithCase(position, false, [
+            (items) => assert.equal(1, items.length),
+            (items) => assert.equal("sidebar_without-header", items[0].label),
+        ])
+    ).catch(err => {
+        assert.ok(false, `error in OpenTextDocument ${err}`);
+    });
+});
+
+test("test camelCase:true style completion", () => {
+    const position = new vscode.Position(5, 21);
+    return Promise.resolve(
+        testCompletionWithCase(position, true, [
+            (items) => assert.equal(1, items.length),
+            (items) => assert.equal("sidebarWithoutHeader", items[0].label),
+        ])
+    ).catch(err => {
+        assert.ok(false, `error in OpenTextDocument ${err}`);
+    });
+});
+
+test("test camelCase:dashes style completion", () => {
+    const position = new vscode.Position(5, 21);
+    return Promise.resolve(
+        testCompletionWithCase(position, "dashes", [
+            (items) => assert.equal(1, items.length),
+            (items) => assert.equal("sidebar_withoutHeader", items[0].label),
+        ])
     ).catch(err => {
         assert.ok(false, `error in OpenTextDocument ${err}`);
     });

--- a/test/fixtures/sample.css
+++ b/test/fixtures/sample.css
@@ -2,3 +2,4 @@
 .header{}
 .body {}
 .footer {}
+.sidebar_without-header {}

--- a/test/fixtures/sample.jsx
+++ b/test/fixtures/sample.jsx
@@ -3,3 +3,4 @@ const styles2 = require("./sample.css");
 
 console.log(styles1.body);
 console.log(styles2.body);
+console.log(styles1.side);


### PR DESCRIPTION
Closes #3.

I've added a setting called 'camelCase', which can be set to 3 possible values: `true | false | 'dashes'`, which output the following autocomplete entries:

For class `.sidebar_with-header`,
Outputs:
`camelCase: false`: `.sidebar_with-header`
`camelCase: true`: `.sidebarWithHeader`
`camelCase: 'dashes'`: `.sidebar_withHeader`