### PR TITLE
Add support for Go to Definitions for camelized classnames

### DIFF
--- a/src/CompletionProvider.ts
+++ b/src/CompletionProvider.ts
@@ -6,7 +6,7 @@ import {
     getAllClassNames,
     getCurrentLine,
 } from "./utils";
-import { CamelCaseValues } from "./utils";
+import { dashesCamelCase, CamelCaseValues } from "./utils";
 
 // check if current character or last character is .
 function isTrigger(line: string, position: Position): boolean {
@@ -22,14 +22,6 @@ function getWords(line: string, position: Position): string {
     }
 
     return text.slice(index);
-}
-
-// from css-loader's implementation
-// source: https://github.com/webpack-contrib/css-loader/blob/22f6621a175e858bb604f5ea19f9860982305f16/lib/compile-exports.js
-function dashesCamelCase(str) {
-  return str.replace(/-(\w)/g, function(match, firstLetter) {
-    return firstLetter.toUpperCase();
-  });
 }
 
 export class CSSModuleCompletionProvider implements CompletionItemProvider {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -23,7 +23,7 @@ export function activate(context: ExtensionContext) {
         languages.registerCompletionItemProvider(mode, new CSSModuleCompletionProvider(camelCaseConfig), ".")
     );
     context.subscriptions.push(
-        languages.registerDefinitionProvider(mode, new CSSModuleDefinitionProvider())
+        languages.registerDefinitionProvider(mode, new CSSModuleDefinitionProvider(camelCaseConfig))
     );
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -41,4 +41,12 @@ export function getAllClassNames(filePath: string, keyword: string): string[] {
     return keyword !== "" ? uniqNames.filter(item => item.indexOf(keyword) !== -1) : uniqNames;
 }
 
+// from css-loader's implementation
+// source: https://github.com/webpack-contrib/css-loader/blob/22f6621a175e858bb604f5ea19f9860982305f16/lib/compile-exports.js
+export function dashesCamelCase(str) {
+  return str.replace(/-(\w)/g, function(match, firstLetter) {
+    return firstLetter.toUpperCase();
+  });
+}
+
 export type CamelCaseValues = false | true | "dashes";

--- a/test/DefinitionProvider.test.ts
+++ b/test/DefinitionProvider.test.ts
@@ -3,6 +3,8 @@ import * as vscode from "vscode";
 import * as path from "path";
 import { CSSModuleDefinitionProvider } from "../src/DefinitionProvider";
 
+import { CamelCaseValues } from "../src/utils";
+
 const rootPath = path.join(__dirname, "../..");
 const tsxFile = path.join(rootPath, "./test/fixtures/sample.jsx");
 const uri = vscode.Uri.file(tsxFile);
@@ -17,20 +19,53 @@ function testDefinition(position: vscode.Position) {
     });
 }
 
+function testDefinitionWithCase(position: vscode.Position, camelCaseConfig: CamelCaseValues, assertions: Array<Function>) {
+    return vscode.workspace.openTextDocument(uri).then(text => {
+        const provider = new CSSModuleDefinitionProvider(camelCaseConfig);
+        return provider.provideDefinition(text, position, undefined).then(location => {
+            const position = location ? location.range.start : null;
+            assertions.map((assertion) => assertion(position));
+        });
+    });
+}
+
 test("testing es6 style definition", () => {
     const position = new vscode.Position(3, 21);
     return Promise.resolve(
         testDefinition(position)
-    ).catch(err => {
-        assert.ok(false, `error in OpenTextDocument ${err}`);
-    });
+    ).catch(err => assert.ok(false, `error in OpenTextDocument ${err}`));
 });
 
 test("testing commonJS style definition", () => {
     const position = new vscode.Position(4, 21);
     return Promise.resolve(
         testDefinition(position)
-    ).catch(err => {
-        assert.ok(false, `error in OpenTextDocument ${err}`);
-    });
+    ).catch(err => assert.ok(false, `error in OpenTextDocument ${err}`));
+});
+
+test("test camelCase:false style definition", () => {
+    const position = new vscode.Position(6, 21);
+    return Promise.resolve(
+        testDefinitionWithCase(position, false, [
+            (position?: vscode.Position) => assert.equal(true, position === null),
+        ])
+    ).catch(err => assert.ok(false, `error in OpenTextDocument ${err}`));
+});
+
+test("test camelCase:true style completion", () => {
+    const position = new vscode.Position(6, 21);
+    return Promise.resolve(
+        testDefinitionWithCase(position, true, [
+            (position?: vscode.Position) => assert.equal(true, position.line === 4 && position.character === 1),
+        ])
+    ).catch(err => assert.ok(false, `error in OpenTextDocument ${err}`));
+});
+
+test("test camelCase:dashes style completion", () => {
+    const position = new vscode.Position(7, 21);
+    return Promise.resolve(
+        testDefinitionWithCase(position, "dashes", [
+            (position?: vscode.Position) => assert.equal(true, position.line === 4 && position.character === 1),
+        ])
+    ).catch(err => assert.ok(false, `error in OpenTextDocument ${err}`));
 });

--- a/test/fixtures/sample.css
+++ b/test/fixtures/sample.css
@@ -1,5 +1,5 @@
 .container {}
-.header{}
+.header {}
 .body {}
 .footer {}
 .sidebar_without-header {}

--- a/test/fixtures/sample.jsx
+++ b/test/fixtures/sample.jsx
@@ -4,3 +4,5 @@ const styles2 = require("./sample.css");
 console.log(styles1.body);
 console.log(styles2.body);
 console.log(styles1.side);
+console.log(styles1.sidebarWithoutHeader);
+console.log(styles1.sidebar_withoutHeader);


### PR DESCRIPTION
This PR enables goto definition for classnames which are used in their camelcase or 'dashed'-camelcase forms too.

Also,
> The only way to guarantee that a position will be returned for a camelized class
is to check after camelizing the source line.
Doing the opposite -- uncamelizing the used classname -- would not always give
correct result, as camelization is lossy.
i.e. `.button--disabled`, `.button-disabled` both give same
final class: `css.buttonDisabled`, and going back from this to that is not possble.

> But this has a drawback - camelization of a line may change the final
positions of classes. But as of now, I don't see a better way, and getting this
working is more important, also putting this functionality out there would help
get more eyeballs and hopefully a better way.