### PR TITLE
Add support for absolute paths

### DIFF
--- a/src/CompletionProvider.ts
+++ b/src/CompletionProvider.ts
@@ -1,4 +1,4 @@
-import { CompletionItemProvider, TextDocument, Position, CompletionItem, CompletionItemKind, workspace } from "vscode";
+import { CompletionItemProvider, TextDocument, Position, CompletionItem, CompletionItemKind } from "vscode";
 import * as path from "path";
 import * as _ from "lodash";
 import {
@@ -42,7 +42,6 @@ export class CSSModuleCompletionProvider implements CompletionItemProvider {
     provideCompletionItems(document: TextDocument, position: Position): Thenable<CompletionItem[]> {
         const currentLine = getCurrentLine(document, position);
         const currentDir = path.dirname(document.uri.fsPath);
-        const workspaceDir = workspace.rootPath;
 
         if (!isTrigger(currentLine, position)) {
             return Promise.resolve([]);
@@ -55,7 +54,7 @@ export class CSSModuleCompletionProvider implements CompletionItemProvider {
 
         const [obj, field] = words.split(".");
 
-        const importPath = findImportPath(document.getText(), obj, currentDir, workspaceDir);
+        const importPath = findImportPath(document.getText(), obj, currentDir);
         if (importPath === "") {
             return Promise.resolve([]);
         }

--- a/src/CompletionProvider.ts
+++ b/src/CompletionProvider.ts
@@ -1,4 +1,4 @@
-import { CompletionItemProvider, TextDocument, Position, CompletionItem, CompletionItemKind } from "vscode";
+import { CompletionItemProvider, TextDocument, Position, CompletionItem, CompletionItemKind, workspace } from "vscode";
 import * as path from "path";
 import * as _ from "lodash";
 import {
@@ -42,6 +42,7 @@ export class CSSModuleCompletionProvider implements CompletionItemProvider {
     provideCompletionItems(document: TextDocument, position: Position): Thenable<CompletionItem[]> {
         const currentLine = getCurrentLine(document, position);
         const currentDir = path.dirname(document.uri.fsPath);
+        const workspaceDir = workspace.rootPath;
 
         if (!isTrigger(currentLine, position)) {
             return Promise.resolve([]);
@@ -54,7 +55,7 @@ export class CSSModuleCompletionProvider implements CompletionItemProvider {
 
         const [obj, field] = words.split(".");
 
-        const importPath = findImportPath(document.getText(), obj, currentDir);
+        const importPath = findImportPath(document.getText(), obj, currentDir, workspaceDir);
         if (importPath === "") {
             return Promise.resolve([]);
         }

--- a/src/DefinitionProvider.ts
+++ b/src/DefinitionProvider.ts
@@ -1,4 +1,4 @@
-import { DefinitionProvider, TextDocument, Position, CancellationToken, Location, Uri } from "vscode";
+import { DefinitionProvider, TextDocument, Position, CancellationToken, Location, Uri, workspace } from "vscode";
 import { getCurrentLine, findImportPath, genImportRegExp, dashesCamelCase, CamelCaseValues } from "./utils";
 import * as path from "path";
 import * as fs from "fs";
@@ -100,12 +100,14 @@ export class CSSModuleDefinitionProvider implements DefinitionProvider {
 
     public provideDefinition(document: TextDocument, position: Position, token: CancellationToken): Thenable<Location> {
         const currentDir = path.dirname(document.uri.fsPath);
+        const workspaceDir = workspace.rootPath;
         const currentLine = getCurrentLine(document, position);
 
         const matches = genImportRegExp("(\\S+)").exec(currentLine);
         if (isImportLineMatch(currentLine, matches, position.character)) {
+            const basePath = matches[2].charAt(0) === "." ? currentDir : workspaceDir;
             return Promise.resolve(new Location(
-                Uri.file(path.resolve(currentDir, matches[2])),
+                Uri.file(path.resolve(basePath, matches[2])),
                 new Position(0, 0)
             ));
         }
@@ -116,7 +118,7 @@ export class CSSModuleDefinitionProvider implements DefinitionProvider {
         }
 
         const [obj, field] = words.split(".");
-        const importPath = findImportPath(document.getText(), obj, currentDir);
+        const importPath = findImportPath(document.getText(), obj, currentDir, workspaceDir);
         if (importPath === "") {
             return Promise.resolve(null);
         }

--- a/src/DefinitionProvider.ts
+++ b/src/DefinitionProvider.ts
@@ -1,4 +1,4 @@
-import { DefinitionProvider, TextDocument, Position, CancellationToken, Location, Uri, workspace } from "vscode";
+import { DefinitionProvider, TextDocument, Position, CancellationToken, Location, Uri } from "vscode";
 import { getCurrentLine, findImportPath, genImportRegExp, dashesCamelCase, CamelCaseValues } from "./utils";
 import * as path from "path";
 import * as fs from "fs";
@@ -100,14 +100,12 @@ export class CSSModuleDefinitionProvider implements DefinitionProvider {
 
     public provideDefinition(document: TextDocument, position: Position, token: CancellationToken): Thenable<Location> {
         const currentDir = path.dirname(document.uri.fsPath);
-        const workspaceDir = workspace.rootPath;
         const currentLine = getCurrentLine(document, position);
 
         const matches = genImportRegExp("(\\S+)").exec(currentLine);
         if (isImportLineMatch(currentLine, matches, position.character)) {
-            const basePath = matches[2].charAt(0) === "." ? currentDir : workspaceDir;
             return Promise.resolve(new Location(
-                Uri.file(path.resolve(basePath, matches[2])),
+                Uri.file(findImportPath(document.getText(), "", currentDir)),
                 new Position(0, 0)
             ));
         }
@@ -118,7 +116,7 @@ export class CSSModuleDefinitionProvider implements DefinitionProvider {
         }
 
         const [obj, field] = words.split(".");
-        const importPath = findImportPath(document.getText(), obj, currentDir, workspaceDir);
+        const importPath = findImportPath(document.getText(), obj, currentDir);
         if (importPath === "") {
             return Promise.resolve(null);
         }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -15,11 +15,12 @@ export function genImportRegExp(key: string ): RegExp {
     return new RegExp(pattern);
 }
 
-export function findImportPath(text: string, key: string, parentPath: string): string {
+export function findImportPath(text: string, key: string, parentPath: string, workspacePath: string): string {
     const re = genImportRegExp(key);
     const results = re.exec(text);
+    const basePath = results[1].charAt(0) === "." ? parentPath : workspacePath;
     if (!!results && results.length > 0) {
-        return path.resolve(parentPath, results[1]);
+        return path.resolve(basePath, results[1]);
     } else {
         return "";
     }


### PR DESCRIPTION
If an import path is matched that does not start with '.', try to resolve the path with the workspace root path. Closes #19.