### PR TITLE
chore: add github actions ci and fix eslint error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,5 @@ jobs:
       - uses: actions/setup-node@v2
         with:
          node-version: '14'
-         cache: 'yarn'
       - run: yarn install
       - run: yarn test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ name: VSCode Test
 on: [push, pull_request]
 
 jobs:
-  VSCode Test:
+  VSCode-Test:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,3 +17,4 @@ jobs:
          cache: 'yarn'
       - run: yarn install
       - run: yarn test
+      

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,8 @@ name: VSCode Test
 on: [push, pull_request]
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
+  VSCode Test:
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
       - uses: actions/setup-node@v2
         with:
          node-version: '14'
+         cache: 'yarn'
       - run: yarn install
       - run: yarn test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+# Github actions workflow name
+name: VSCode Test
+
+# Triggers the workflow on push or pull request events
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v2
+        with:
+         node-version: '14'
+         cache: 'yarn'
+      - run: yarn install
+      - run: yarn test

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # VSCode CSS Modules
 
-[![Github Actions](https://github.com/ichenlei/vscode-css-modules/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/clinyong/vscode-css-modules/actions)
+[![Github Actions](https://github.com/clinyong/vscode-css-modules/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/clinyong/vscode-css-modules/actions)
 
 Extension for [CSS Modules](https://github.com/css-modules/css-modules), which supports
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # VSCode CSS Modules
 
-[![Build Status](https://travis-ci.org/clinyong/vscode-css-modules.svg?branch=master)](https://travis-ci.org/clinyong/vscode-css-modules)
+[![Github Actions](https://github.com/ichenlei/vscode-css-modules/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/clinyong/vscode-css-modules/actions)
 
 Extension for [CSS Modules](https://github.com/css-modules/css-modules), which supports
 
@@ -27,7 +27,7 @@ If you write `kebab-case` classes in css files, but want to get `camelCase` comp
 
 ```json
 {
-   "cssModules.camelCase": true
+  "cssModules.camelCase": true
 }
 ```
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,7 +4,7 @@ import { CSSModuleCompletionProvider } from "./CompletionProvider";
 import { CSSModuleDefinitionProvider } from "./DefinitionProvider";
 import { readOptions } from "./options";
 
-export function activate(context: ExtensionContext) {
+export function activate(context: ExtensionContext): void {
   const mode: DocumentFilter[] = [
     { language: "typescriptreact", scheme: "file" },
     { language: "javascriptreact", scheme: "file" },
@@ -26,4 +26,4 @@ export function activate(context: ExtensionContext) {
   );
 }
 
-export function deactivate() {}
+export function deactivate(): void {}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -29,7 +29,7 @@ export function getAllClassNames(filePath: string, keyword: string): string[] {
 
 // from css-loader's implementation
 // source: https://github.com/webpack-contrib/css-loader/blob/22f6621a175e858bb604f5ea19f9860982305f16/lib/compile-exports.js
-export function dashesCamelCase(str) {
+export function dashesCamelCase(str: string): string {
   return str.replace(/-(\w)/g, function (match, firstLetter) {
     return firstLetter.toUpperCase();
   });


### PR DESCRIPTION
`travis-ci.org` services is down(Since June 15th, 2021, the building on travis-ci.org is ceased. Please use travis-ci.com from now on.), github acitons ci is a better alternative for this project

> Why test on `macos-latest` ?  `ubuntu-latest` will encount `The futex facility returned an unexpected error code` error, look more detail -> https://github.com/electron/electron/issues/24211
vscode headless test depend on electron headless, it will crash when run on ubuntu without special options config.