### PR TITLE
chore: make getAllClassNames function async

### DIFF
--- a/src/CompletionProvider.ts
+++ b/src/CompletionProvider.ts
@@ -74,7 +74,7 @@ export class CSSModuleCompletionProvider implements CompletionItemProvider {
       return Promise.resolve([]);
     }
 
-    const classNames = getAllClassNames(importPath, field);
+    const classNames = await getAllClassNames(importPath, field);
 
     return Promise.resolve(
       classNames.map((_class) => {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -9,8 +9,8 @@ export function getCurrentLine(
   return document.getText(document.lineAt(position).range);
 }
 
-export function getAllClassNames(filePath: string, keyword: string): string[] {
-  const content = fse.readFileSync(filePath, { encoding: "utf8" });
+export async function getAllClassNames(filePath: string, keyword: string): Promise<string[]> {
+  const content = await fse.readFile(filePath, { encoding: "utf8" });
   const lines = content.match(/.*[,{]/g);
   if (lines === null) {
     return [];


### PR DESCRIPTION
Make `getAllClassNames` async to avoid block VSCode editor.
Cause no CI currently, so please merge it after https://github.com/clinyong/vscode-css-modules/pull/35

/cc @clinyong 