### PR TITLE
fix: spread operator issues

### DIFF
--- a/src/DefinitionProvider.ts
+++ b/src/DefinitionProvider.ts
@@ -167,6 +167,11 @@ function getKeyword(currentLine: string, position: Position): Keyword | null {
   }
 
   const [obj, field] = words.split(".");
+  if (!obj || !field) {
+    // probably a spread operator
+    return null;
+  }
+
   return { obj, field };
 }
 


### PR DESCRIPTION
issue repro here: https://github.com/forivall/vscode-css-modules-issue-repro

from `index.js` use go to definition on _foo3. It tries to open a directory. I think this fixes that issue, but i havent tested yet.