### PR TITLE
ci: update HaaLeo/publish-vscode-extension

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,12 +18,12 @@ jobs:
          cache: 'yarn'
       - run: yarn install
       - name: Publish to Open VSX Registry
-        uses: HaaLeo/publish-vscode-extension@v0
+        uses: HaaLeo/publish-vscode-extension@v1
         with:
           pat: ${{ secrets.OPEN_VSX_TOKEN }}
           yarn: true
       - name: Publish to Visual Studio Marketplace
-        uses: HaaLeo/publish-vscode-extension@v0
+        uses: HaaLeo/publish-vscode-extension@v1
         with:
           pat: ${{ secrets.VS_MARKETPLACE_TOKEN }}
           registryUrl: https://marketplace.visualstudio.com

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,7 @@ jobs:
           fetch-depth: 2
       - uses: actions/setup-node@v2
         with:
-         node-version: '14'
+         node-version: '18'
          cache: 'yarn'
       - run: yarn install
       - name: Publish to Open VSX Registry

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: 2
       - uses: actions/setup-node@v2
         with:
-         node-version: '14'
+         node-version: '18'
          cache: 'yarn'
       - run: yarn install
       - run: yarn test


### PR DESCRIPTION
https://github.com/HaaLeo/publish-vscode-extension/blob/master/CHANGELOG.md#v100-2021-12-17

https://code.visualstudio.com/api/working-with-extensions/publishing-extension#extension-sponsor
> Note: Make sure to use the vsce version >= 2.9.1 when publishing your extension for sponsorship to work.