### PR TITLE
Implement support for bracket syntax, fixes #70

### DIFF
--- a/src/CompletionProvider.ts
+++ b/src/CompletionProvider.ts
@@ -3,27 +3,45 @@ import {
   TextDocument,
   Position,
   CompletionItem,
-  CompletionItemKind
+  CompletionItemKind,
 } from "vscode";
 import * as path from "path";
 import * as _ from "lodash";
-import { getAllClassNames, getCurrentLine, dashesCamelCase, isKebabCaseClassName, createBracketCompletionItem } from "./utils";
+import {
+  getAllClassNames,
+  getCurrentLine,
+  dashesCamelCase,
+  isKebabCaseClassName,
+  createBracketCompletionItem,
+} from "./utils";
 import { findImportModule, resolveImportPath } from "./utils/path";
 import { AliasFromUserOptions, ExtensionOptions } from "./options";
 import { getRealPathAlias } from "./path-alias";
 
 // check if current character or last character is .
+// or if current character is " or ' after a [
 function isTrigger(line: string, position: Position): boolean {
   const i = position.character - 1;
-  return line[i] === "." || (i > 1 && line[i - 1] === ".");
+  const isDotSyntax = line[i] === "." || (i > 1 && line[i - 1] === ".");
+  if (isDotSyntax) {
+    return true;
+  }
+
+  const isBracketSyntax =
+    line[i - 1] === "[" && (line[i] === '"' || line[i] === "'");
+  if (isBracketSyntax) {
+    return true;
+  }
+
+  return false;
 }
 
 function getWords(line: string, position: Position): string {
   const text = line.slice(0, position.character);
   // support optional chain https://github.com/tc39/proposal-optional-chaining
   // covert ?. to .
-  const convertText = text.replace(/(\?\.)/g, '.');
-  const index = convertText.search(/[a-zA-Z0-9._]*$/);
+  const convertText = text.replace(/(\?\.)/g, ".");
+  const index = convertText.search(/[a-zA-Z0-9._["']*$/);
   if (index === -1) {
     return "";
   }
@@ -61,12 +79,13 @@ export class CSSModuleCompletionProvider implements CompletionItemProvider {
       return Promise.resolve([]);
     }
 
+    const splitRegex = /\.|\["|\['/;
     const words = getWords(currentLine, position);
-    if (words === "" || words.indexOf(".") === -1) {
+    if (words === "" || !splitRegex.test(words)) {
       return Promise.resolve([]);
     }
 
-    const [obj, field] = words.split(".");
+    const [obj, field] = words.split(splitRegex);
 
     const importModule = findImportModule(document.getText(), obj);
     const importPath = await resolveImportPath(
@@ -88,7 +107,7 @@ export class CSSModuleCompletionProvider implements CompletionItemProvider {
         }
         if (isKebabCaseClassName(name)) {
           return createBracketCompletionItem(name, position);
-        } 
+        }
         return new CompletionItem(name, CompletionItemKind.Variable);
       })
     );

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,13 +14,16 @@ export function activate(context: ExtensionContext): void {
     { language: "astro", scheme: "file" },
   ];
   const options = readOptions();
-  context.subscriptions.push(
-    languages.registerCompletionItemProvider(
-      mode,
-      new CSSModuleCompletionProvider(options),
-      "."
-    )
-  );
+  const triggerCharacters = [".", "\"", "'"]
+  triggerCharacters.forEach(char => {
+    context.subscriptions.push(
+      languages.registerCompletionItemProvider(
+        mode,
+        new CSSModuleCompletionProvider(options),
+        char
+      )
+    );
+  })
   context.subscriptions.push(
     languages.registerDefinitionProvider(
       mode,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,16 +14,15 @@ export function activate(context: ExtensionContext): void {
     { language: "astro", scheme: "file" },
   ];
   const options = readOptions();
-  const triggerCharacters = [".", "\"", "'"]
-  triggerCharacters.forEach(char => {
     context.subscriptions.push(
       languages.registerCompletionItemProvider(
         mode,
         new CSSModuleCompletionProvider(options),
-        char
+        ".",
+        "\"",
+        "'"
       )
     );
-  })
   context.subscriptions.push(
     languages.registerDefinitionProvider(
       mode,

--- a/src/test/fixtures/sample.jsx
+++ b/src/test/fixtures/sample.jsx
@@ -13,3 +13,10 @@ v?.a; // don't match anything
 styles1?. // support optional chain
 const es1 = {};
 es1. // don't match styles1
+
+// Support bracket notation
+styles1["
+styles1['
+styles1[""]
+styles1['']
+

--- a/src/test/fixtures/sample.jsx
+++ b/src/test/fixtures/sample.jsx
@@ -14,9 +14,12 @@ styles1?. // support optional chain
 const es1 = {};
 es1. // don't match styles1
 
-// Support bracket notation
+// Support autocompletion with bracket notation
 styles1["
 styles1['
 styles1[""]
 styles1['']
 
+// issue-#70
+console.log(styles1["body"]);
+console.log(styles1['body']);

--- a/src/test/suite/CompletionProvider.test.ts
+++ b/src/test/suite/CompletionProvider.test.ts
@@ -3,7 +3,13 @@ import * as vscode from "vscode";
 
 import { CSSModuleCompletionProvider } from "../../CompletionProvider";
 import { CamelCaseValues } from "../../options";
-import { SAMPLE_JSX_FILE, SAMPLE_JS_FILE, SAMPLE_TSX_FILE, SAMPLE_TS_FILE, STYLUS_JSX_FILE } from "../constant";
+import {
+  SAMPLE_JSX_FILE,
+  SAMPLE_JS_FILE,
+  SAMPLE_TSX_FILE,
+  SAMPLE_TS_FILE,
+  STYLUS_JSX_FILE,
+} from "../constant";
 import { readOptions } from "../utils";
 
 const uri = vscode.Uri.file(SAMPLE_JSX_FILE);
@@ -12,7 +18,11 @@ const uri3 = vscode.Uri.file(SAMPLE_JS_FILE);
 const uri4 = vscode.Uri.file(SAMPLE_TSX_FILE);
 const uri5 = vscode.Uri.file(SAMPLE_TS_FILE);
 
-function testCompletion(position: vscode.Position, itemCount: number, fixtureFile?: vscode.Uri) {
+function testCompletion(
+  position: vscode.Position,
+  itemCount: number,
+  fixtureFile?: vscode.Uri
+) {
   return vscode.workspace.openTextDocument(fixtureFile || uri).then((text) => {
     const provider = new CSSModuleCompletionProvider(readOptions());
     return provider.provideCompletionItems(text, position).then((items) => {
@@ -66,6 +76,34 @@ test("test optional chain valid match", () => {
   });
 });
 
+test("test bracket notation with double quotes and no closing quote valid match", () => {
+  const position = new vscode.Position(17, 9);
+  return Promise.resolve(testCompletion(position, 5)).catch((err) => {
+    assert.ok(false, `error in OpenTextDocument ${err}`);
+  });
+});
+
+test("test bracket notation with single quotes and no closing quote valid match", () => {
+  const position = new vscode.Position(18, 9);
+  return Promise.resolve(testCompletion(position, 5)).catch((err) => {
+    assert.ok(false, `error in OpenTextDocument ${err}`);
+  });
+});
+
+test("test bracket notation with double quotes and closing quote valid match", () => {
+  const position = new vscode.Position(19, 9);
+  return Promise.resolve(testCompletion(position, 5)).catch((err) => {
+    assert.ok(false, `error in OpenTextDocument ${err}`);
+  });
+});
+
+test("test bracket notation with single quotes and closing quote valid match", () => {
+  const position = new vscode.Position(20, 9);
+  return Promise.resolve(testCompletion(position, 5)).catch((err) => {
+    assert.ok(false, `error in OpenTextDocument ${err}`);
+  });
+});
+
 test("test exact Match", () => {
   const position = new vscode.Position(14, 4);
   return Promise.resolve(testCompletion(position, 0)).catch((err) => {
@@ -104,7 +142,8 @@ test("test camelCase:false style and kebab-case completion", () => {
   return Promise.resolve(
     testCompletionWithCase(position, false, [
       (items) => assert.strictEqual(1, items.length),
-      (items) => assert.strictEqual(`['sidebar_without-header']`, items[0].insertText),
+      (items) =>
+        assert.strictEqual(`['sidebar_without-header']`, items[0].insertText),
     ])
   ).catch((err) => {
     assert.ok(false, `error in OpenTextDocument ${err}`);

--- a/src/test/suite/DefinitionProvider.test.ts
+++ b/src/test/suite/DefinitionProvider.test.ts
@@ -181,3 +181,17 @@ test("ignore spread syntax", async () => {
   );
   assert.deepStrictEqual(result, null);
 });
+
+test("test bracket definition with double quotes jump to definition", () => {
+  const position = new vscode.Position(23, 22);
+  return Promise.resolve(testDefinition(position, 2, 1)).catch((err) =>
+    assert.ok(false, `error in OpenTextDocument ${err}`)
+  );
+});
+
+test("test bracket definition with single quotes jump to definition", () => {
+  const position = new vscode.Position(24, 22);
+  return Promise.resolve(testDefinition(position, 2, 1)).catch((err) =>
+    assert.ok(false, `error in OpenTextDocument ${err}`)
+  );
+});


### PR DESCRIPTION
- Implemented "Jump to definition" for bracket syntax
- Implemented autocomplete for bracket syntax

Still missing support for combining optional chaining with bracket syntax, e.g. `styles?.["mainButton"]`. I didn't implement it because I don't know how important it is (I don't need it), but I can try implementing it in this PR if you want :)

Fixes #70 

P.S. There were some style changes enforced by editorconfig, that's why there are so many unrelated changes.

