### PR TITLE
fix: kebab-casing should work in multicursor completion

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -65,7 +65,10 @@ export function createBracketCompletionItem (className: string, position: Positi
   completionItem.detail = `['${className}']`;
   completionItem.documentation = "kebab-casing may cause unexpected behavior when trying to access style.class-name as a dot notation. You can still work around kebab-case with bracket notation (eg. style['class-name']) but style.className is cleaner.";
   completionItem.insertText = `['${className}']`;
-  completionItem.additionalTextEdits = [new TextEdit(new Range(new Position(position.line, position.character - 1),
-      new Position(position.line, position.character)), '')];
+  // .className -> ['className']
+  // set filterText to match .className
+  // https://github.com/microsoft/vscode/issues/113551#issuecomment-754158355
+  completionItem.filterText = `.${className}`
+  completionItem.range = new Range(new Position(position.line, position.character - 1), position);
   return completionItem;
 }


### PR DESCRIPTION
When using multiple cursors to complete kebab-case class names, only the first line removes the "." , while other lines still retain the ".".

![issue](https://github.com/clinyong/vscode-css-modules/assets/16460309/ab97a06a-5c47-4a3d-9a40-70a0ed3263be)

According to [the discussion](https://github.com/microsoft/vscode/issues/113551#issuecomment-753835904), additionalTextEdits do not affect other lines.

> Since additional text edits are "precise", e.g. naming a range and text, we cannot multiply them with each cursor location. However, the main edit of a completion will be applied for each cursor. So, ideally the c++ extension doesn't need additional text edits for this.

Therefore, instead of using `additionalTextEdits`, we set the range directly to include the "." for replacement.

![fixed](https://github.com/clinyong/vscode-css-modules/assets/16460309/15d9399c-058b-431d-8741-1216983c26de)

